### PR TITLE
New CookieName Option.

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -24,6 +24,8 @@ const (
 var (
 	// The name value used in form fields.
 	fieldName = tokenKey
+	// defaultAge sets the default MaxAge for cookies.
+	defaultAge = 3600 * 12
 	// The default HTTP request header to inspect
 	headerName = "X-CSRF-Token"
 	// Idempotent (safe) methods as defined by RFC7231 section 4.2.2.
@@ -67,6 +69,7 @@ type options struct {
 	RequestHeader string
 	FieldName     string
 	ErrorHandler  http.Handler
+	CookieName    string
 }
 
 // Protect is HTTP middleware that provides Cross-Site Request Forgery
@@ -123,11 +126,15 @@ func Protect(authKey []byte, opts ...func(*csrf)) func(http.Handler) http.Handle
 
 		if cs.opts.MaxAge < 1 {
 			// Default of 12 hours
-			cs.opts.MaxAge = 3600 * 12
+			cs.opts.MaxAge = defaultAge
 		}
 
 		if cs.opts.FieldName == "" {
 			cs.opts.FieldName = fieldName
+		}
+
+		if cs.opts.CookieName == "" {
+			cs.opts.CookieName = cookieName
 		}
 
 		if cs.opts.RequestHeader == "" {
@@ -144,7 +151,7 @@ func Protect(authKey []byte, opts ...func(*csrf)) func(http.Handler) http.Handle
 		if cs.st == nil {
 			// Default to the cookieStore
 			cs.st = &cookieStore{
-				name:   cookieName,
+				name:   cs.opts.CookieName,
 				maxAge: cs.opts.MaxAge,
 				sc:     cs.sc,
 			}

--- a/options.go
+++ b/options.go
@@ -80,6 +80,16 @@ func FieldName(name string) func(*csrf) {
 	}
 }
 
+// CookieName changes the name of the CSRF cookie issued to clients.
+//
+// Note that cookie names should not contain whitespace, commas, semicolons,
+// backslashes or control characters as per RFC6265.
+func CookieName(name string) func(*csrf) {
+	return func(cs *csrf) {
+		cs.opts.CookieName = name
+	}
+}
+
 // setStore sets the store used by the CSRF middleware.
 // Note: this is private (for now) to allow for internal API changes.
 func setStore(s store) func(*csrf) {

--- a/options_test.go
+++ b/options_test.go
@@ -16,6 +16,7 @@ func TestOptions(t *testing.T) {
 	header := "X-AUTH-TOKEN"
 	field := "authenticity_token"
 	errorHandler := unauthorizedHandler
+	name := "_chimpanzee_csrf"
 
 	testOpts := []func(*csrf){
 		MaxAge(age),
@@ -26,6 +27,7 @@ func TestOptions(t *testing.T) {
 		RequestHeader(header),
 		FieldName(field),
 		ErrorHandler(http.HandlerFunc(errorHandler)),
+		CookieName(name),
 	}
 
 	// Parse our test options and check that they set the related struct fields.
@@ -62,5 +64,10 @@ func TestOptions(t *testing.T) {
 	if !reflect.ValueOf(cs.opts.ErrorHandler).IsValid() {
 		t.Errorf("ErrorHandler not set correctly: got %v want %v",
 			reflect.ValueOf(cs.opts.ErrorHandler).IsValid(), reflect.ValueOf(errorHandler).IsValid())
+	}
+
+	if cs.opts.CookieName != name {
+		t.Errorf("CookieName not set correctly: got %v want %v",
+			cs.opts.CookieName, name)
 	}
 }


### PR DESCRIPTION
CookieName changes the name of the CSRF cookie issued to clients.

Note that cookie names should not contain whitespace, commas, semicolons, backslashes or control characters as per RFC6265.