### PR TITLE
docs: Clarified need to persist authentication keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ http.ListenAndServe(":8000", CSRF(r))
 ...and then collect the token with `csrf.Token(r)` in your handlers before
 passing it to the template, JSON body or HTTP header (see below).
 
+Note that the authentication key passed to `csrf.Protect([]byte(key))` should be
+32-bytes long and persist across application restarts. Generating a random key
+won't allow you to authenticate existing cookies and will break your CSRF
+validation.
+
 gorilla/csrf inspects the form body (first) and HTTP headers (second) on
 subsequent POST/PUT/PATCH/DELETE/etc. requests for the token.
 

--- a/csrf.go
+++ b/csrf.go
@@ -100,6 +100,8 @@ type options struct {
 //
 //	  // Add the middleware to your router.
 //	  http.ListenAndServe(":8000",
+//            // Note that the authentication key provided should be 32 bytes
+//            // long and persist across application restarts.
 //			  csrf.Protect([]byte("32-byte-long-auth-key"))(r))
 //	}
 //

--- a/doc.go
+++ b/doc.go
@@ -23,6 +23,11 @@ template, JSON body or HTTP header (you pick!). gorilla/csrf inspects the form b
 (first) and HTTP headers (second) on subsequent POST/PUT/PATCH/DELETE/etc. requests
 for the token.
 
+Note that the authentication key passed to `csrf.Protect([]byte(key))` should be
+32-bytes long and persist across application restarts. Generating a random key
+won't allow you to authenticate existing cookies and will break your CSRF
+validation.
+
 Here's the common use-case: HTML forms you want to provide CSRF protection for,
 in order to protect malicious POST requests being made:
 


### PR DESCRIPTION
As per https://twitter.com/kisielk/status/639531421283958784 - clarified docs around the need to persist authentication (cookie signing) keys.