### PR TITLE
Fixed Missing Secure & HttpOnly Defaults

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -153,9 +153,11 @@ func Protect(authKey []byte, opts ...func(*csrf)) func(http.Handler) http.Handle
 		if cs.st == nil {
 			// Default to the cookieStore
 			cs.st = &cookieStore{
-				name:   cs.opts.CookieName,
-				maxAge: cs.opts.MaxAge,
-				sc:     cs.sc,
+				name:     cs.opts.CookieName,
+				maxAge:   cs.opts.MaxAge,
+				secure:   cs.opts.Secure,
+				httpOnly: cs.opts.HttpOnly,
+				sc:       cs.sc,
 			}
 		}
 

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -33,6 +33,12 @@ func TestProtect(t *testing.T) {
 	if rr.Header().Get("Set-Cookie") == "" {
 		t.Fatalf("cookie not set: got %q", rr.Header().Get("Set-Cookie"))
 	}
+
+	cookie := rr.Header().Get("Set-Cookie")
+	if !strings.Contains(cookie, "HttpOnly") || !strings.Contains(cookie,
+		"Secure") {
+		t.Fatalf("cookie does not default to Secure & HttpOnly: got %v", cookie)
+	}
 }
 
 // Test that idempotent methods return a 200 OK status and that non-idempotent

--- a/store.go
+++ b/store.go
@@ -21,9 +21,11 @@ type store interface {
 
 // cookieStore is a signed cookie session store for CSRF tokens.
 type cookieStore struct {
-	name   string
-	maxAge int
-	sc     *securecookie.SecureCookie
+	name     string
+	maxAge   int
+	secure   bool
+	httpOnly bool
+	sc       *securecookie.SecureCookie
 }
 
 // Get retrieves a CSRF token from the session cookie. It returns an empty token
@@ -54,9 +56,11 @@ func (cs *cookieStore) Save(token []byte, w http.ResponseWriter) error {
 	}
 
 	cookie := &http.Cookie{
-		Name:   cs.name,
-		Value:  encoded,
-		MaxAge: cs.maxAge,
+		Name:     cs.name,
+		Value:    encoded,
+		MaxAge:   cs.maxAge,
+		HttpOnly: cs.httpOnly,
+		Secure:   cs.secure,
 	}
 
 	// Set the Expires field on the cookie based on the MaxAge

--- a/store_test.go
+++ b/store_test.go
@@ -51,6 +51,7 @@ func TestStoreCannotSave(t *testing.T) {
 		t.Fatalf("broken store incorrectly set a cookie: got %v want %v",
 			c, "")
 	}
+
 }
 
 // TestCookieDecode tests that an invalid cookie store returns a decoding error.
@@ -65,7 +66,7 @@ func TestCookieDecode(t *testing.T) {
 	// Test with a nil hash key
 	sc := securecookie.New(nil, nil)
 	sc.MaxAge(age)
-	st := &cookieStore{cookieName, age, sc}
+	st := &cookieStore{cookieName, age, true, true, sc}
 
 	// Set a fake cookie value so r.Cookie passes.
 	r.Header.Set("Cookie", fmt.Sprintf("%s=%s", cookieName, "notacookie"))
@@ -83,7 +84,7 @@ func TestCookieEncode(t *testing.T) {
 	// Test with a nil hash key
 	sc := securecookie.New(nil, nil)
 	sc.MaxAge(age)
-	st := &cookieStore{cookieName, age, sc}
+	st := &cookieStore{cookieName, age, true, true, sc}
 
 	rr := httptest.NewRecorder()
 


### PR DESCRIPTION
* Cookies were not correctly being written out with `Secure` and `HttpOnly` parameters
* This has been fixed
* Tests have also been added to prevent any regressions

