### PR TITLE
[feature]: Use securecookie.JSONEncoder{}

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -146,6 +146,8 @@ func Protect(authKey []byte, opts ...func(*csrf)) func(http.Handler) http.Handle
 		// Create an authenticated securecookie instance.
 		if cs.sc == nil {
 			cs.sc = securecookie.New(authKey, nil)
+			// Use JSON serialization (faster than one-off gob encoding)
+			cs.sc.SetSerializer(securecookie.JSONEncoder{})
 			// Set the MaxAge of the underlying securecookie.
 			cs.sc.MaxAge(cs.opts.MaxAge)
 		}


### PR DESCRIPTION
- JSONEncoder{} is faster than the default GOBEncoder{}
- The store controls the data structure and is JSON compatible by default

Throwing away an encoder/decoder on every request isn't a good match for gob. As we're just storing ` []byte` our data format is compatible (by default) with encoding/json by default.