### PR TITLE
[docs] Mention csrf.Secure(false) when developing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ func main() {
     // Add the middleware to your router by wrapping it.
     http.ListenAndServe(":8000",
         csrf.Protect([]byte("32-byte-long-auth-key"))(r))
+    // PS: Don't forget to pass csrf.Secure(false) if you're developing locally
+    // over plain HTTP (just don't leave it on in production).
 }
 
 func ShowSignupForm(w http.ResponseWriter, r *http.Request) {

--- a/options.go
+++ b/options.go
@@ -35,6 +35,10 @@ func Path(p string) func(*csrf) {
 }
 
 // Secure sets the 'Secure' flag on the cookie. Defaults to true (recommended).
+// Set this to 'false' in your development environment otherwise the cookie won't
+// be sent over an insecure channel. Setting this via the presence of a 'DEV'
+// environmental variable is a good way of making sure this won't make it to a
+// production environment.
 func Secure(s bool) func(*csrf) {
 	return func(cs *csrf) {
 		cs.opts.Secure = s


### PR DESCRIPTION
Addresses a concern in #13 where failing to set `csrf.Secure(false)` during development results in the expected CSRF failure (as the cookie isn't sent back).