### PR TITLE
[feature] csrf.TemplateField now uses custom FieldNames

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -16,6 +16,7 @@ const tokenLength = 32
 // Context/session keys & prefixes
 const (
 	tokenKey    string = "gorilla.csrf.Token"
+	formKey     string = "gorilla.csrf.Form"
 	errorKey    string = "gorilla.csrf.Error"
 	cookieName  string = "_gorilla_csrf"
 	errorPrefix string = "gorilla/csrf: "
@@ -198,6 +199,8 @@ func (cs *csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Save the masked token to the request context
 	context.Set(r, tokenKey, mask(realToken, r))
+	// Save the field name to the request context
+	context.Set(r, formKey, cs.opts.FieldName)
 
 	// HTTP methods not defined as idempotent ("safe") under RFC7231 require
 	// inspection.

--- a/helpers.go
+++ b/helpers.go
@@ -50,10 +50,15 @@ func FailureReason(r *http.Request) error {
 //      <input type="hidden" name="gorilla.csrf.Token" value="<token>">
 //
 func TemplateField(r *http.Request) template.HTML {
-	fragment := fmt.Sprintf(`<input type="hidden" name="%s" value="%s">`,
-		fieldName, Token(r))
+	name, ok := context.GetOk(r, formKey)
+	if ok {
+		fragment := fmt.Sprintf(`<input type="hidden" name="%s" value="%s">`,
+			name, Token(r))
 
-	return template.HTML(fragment)
+		return template.HTML(fragment)
+	}
+
+	return template.HTML("")
 }
 
 // mask returns a unique-per-request token to mitigate the BREACH attack


### PR DESCRIPTION
Appropriated from https://github.com/goji/csrf/pull/3

Addresses:
* https://github.com/gorilla/csrf/issues/18
* https://github.com/gorilla/csrf/issues/22
* https://github.com/gorilla/csrf/issues/19

We pass the field name in the context so that it's available to `csrf.TemplateField`. 