### PR TITLE
Compare token fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: go
 sudo: false
-go:
-  - 1.4
-  - 1.5
-  - tip
+
+matrix:
+  include:
+    - go: 1.2
+    - go: 1.3
+    - go: 1.4
+    - go: 1.5
+    - go: tip
+
 install:
   - go get golang.org/x/tools/cmd/vet
+
 script:
   - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d -s .)
+  - diff -u <(echo -n) <(gofmt -d .)
   - go tool vet .
   - go test -v -race ./...

--- a/helpers.go
+++ b/helpers.go
@@ -150,11 +150,13 @@ func sameOrigin(a, b *url.URL) bool {
 // compare securely (constant-time) compares the unmasked token from the request
 // against the real token from the session.
 func compareTokens(a, b []byte) bool {
-	if subtle.ConstantTimeCompare(a, b) == 1 {
-		return true
+	// This is required as subtle.ConstantTimeCompare does not check for equal
+	// lengths in Go versions prior to 1.3.
+	if len(a) != len(b) {
+		return false
 	}
 
-	return false
+	return subtle.ConstantTimeCompare(a, b) == 1
 }
 
 // xorToken XORs tokens ([]byte) to provide unique-per-request CSRF tokens. It

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -254,3 +254,14 @@ func TestTemplateField(t *testing.T) {
 			templateField, expectedField)
 	}
 }
+
+func TestCompareTokens(t *testing.T) {
+	// Go's subtle.ConstantTimeCompare prior to 1.3 did not check for matching
+	// lengths.
+	a := []byte("")
+	b := []byte("an-actual-token")
+
+	if v := compareTokens(a, b); v == true {
+		t.Fatalf("compareTokens failed on different tokens: got %v want %v", v, !v)
+	}
+}


### PR DESCRIPTION
Also as per https://github.com/goji/csrf/pull/8

- subtle.ConstantTimeCompare did not check for matching slice lengths prior to Go
  1.3 (fixed in https://codereview.appspot.com/118750043).
- gorilla/csrf was released a year after this came into place.
- Our TravisCI tests did not test against older versions of Go, and this wasn't
  caught as a result.
- Have added Go 1.2 and Go 1.3 to the TravisCI config to address any future
  regressions.