### PR TITLE
[bugfix] Support a cookie MaxAge of 0.

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -127,7 +127,7 @@ func Protect(authKey []byte, opts ...Option) func(http.Handler) http.Handler {
 			cs.opts.ErrorHandler = http.HandlerFunc(unauthorizedHandler)
 		}
 
-		if cs.opts.MaxAge < 1 {
+		if cs.opts.MaxAge < 0 {
 			// Default of 12 hours
 			cs.opts.MaxAge = defaultAge
 		}

--- a/store.go
+++ b/store.go
@@ -68,11 +68,11 @@ func (cs *cookieStore) Save(token []byte, w http.ResponseWriter) error {
 	}
 
 	// Set the Expires field on the cookie based on the MaxAge
+	// If MaxAge <= 0, we don't set the Expires attribute, making the cookie
+	// session-only.
 	if cs.maxAge > 0 {
 		cookie.Expires = time.Now().Add(
 			time.Duration(cs.maxAge) * time.Second)
-	} else {
-		cookie.Expires = time.Unix(1, 0)
 	}
 
 	// Write the authenticated cookie to the response.


### PR DESCRIPTION
- As per #38 - we now support a MaxAge of 0 to allow for session cookie support.
  gorilla/csrf's CSRF tokens are designed to be reasonably long lived (12
  hours), but there are some applications that require this.
- Note that setting a MaxAge < 0 will default to 12 hours, so you must
  explcitly set csrf.MaxAge(0) to invoke this behaviour.