### PR TITLE
remove dependency on gorilla/context for go1.7+

### DIFF
--- a/context.go
+++ b/context.go
@@ -23,3 +23,7 @@ func contextSave(r *http.Request, key string, val interface{}) *http.Request {
 	ctx = context.WithValue(ctx, key, val)
 	return r.WithContext(ctx)
 }
+
+func contextClear(r *http.Request) {
+	// no-op for go1.7+
+}

--- a/context_legacy.go
+++ b/context_legacy.go
@@ -22,3 +22,7 @@ func contextSave(r *http.Request, key string, val interface{}) *http.Request {
 	context.Set(r, key, val)
 	return r
 }
+
+func contextClear(r *http.Request) {
+	context.Clear(r)
+}

--- a/helpers.go
+++ b/helpers.go
@@ -8,8 +8,6 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
-
-	"github.com/gorilla/context"
 )
 
 // Token returns a masked CSRF token ready for passing into HTML template or
@@ -200,6 +198,6 @@ func contains(vals []string, s string) bool {
 }
 
 // envError stores a CSRF error in the request context.
-func envError(r *http.Request, err error) {
-	context.Set(r, errorKey, err)
+func envError(r *http.Request, err error) *http.Request {
+	return contextSave(r, errorKey, err)
 }


### PR DESCRIPTION
Hello,

This finishes what was started a few commits ago by moving the use of `gorilla/context` behind a build tag, so that for Go1.7+ that package isn't used anymore. It adds the missing `contextClear` func, and uses the `contextSave` call to set the error in the context while making sure to change the `*http.Request` to the one returned by `contextSave`.

Thanks,
Martin