### PR TITLE
remove unused variable "token" from TestNoCookie

### DIFF
--- a/csrf_test.go
+++ b/csrf_test.go
@@ -132,11 +132,6 @@ func TestNoCookie(t *testing.T) {
 	s := http.NewServeMux()
 	p := Protect(testKey)(s)
 
-	var token string
-	s.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token = Token(r)
-	}))
-
 	// POST the token back in the header.
 	r, err := http.NewRequest("POST", "http://www.gorillatoolkit.org/", nil)
 	if err != nil {


### PR DESCRIPTION
For some reason the Go compiler does not complain about it, but the `go/types` package does when reading this file.