### PR TITLE
Update LICENSE file to reflect Google employee contributions.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2015, Matt Silverlock (matt@eatsleeprepeat.net) All rights
-reserved.
+Copyright (c) 2015-2018, Matt Silverlock (matt@eatsleeprepeat.net), Google LLC.
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
As per https://opensource.google.com/docs/patching/#common-rules -

> If project authors are listed in a LICENSE, COPYING, AUTHORS or similar file, please add Google LLC. if it’s not already there. If Google Inc. is already listed then there is no need to change it to Google LLC. This step only applies if the project authors are listed somewhere.

Updating this to reflect a few boxes I need to tick.