### PR TITLE
[fix] Use custom string instead of built-in string to prevent collisions with …

### DIFF
--- a/context.go
+++ b/context.go
@@ -9,8 +9,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+type csrfContext string
+
 func contextGet(r *http.Request, key string) (interface{}, error) {
-	val := r.Context().Value(key)
+	val := r.Context().Value(csrfContext(key))
 	if val == nil {
 		return nil, errors.Errorf("no value exists in the context for key %q", key)
 	}
@@ -20,7 +22,7 @@ func contextGet(r *http.Request, key string) (interface{}, error) {
 
 func contextSave(r *http.Request, key string, val interface{}) *http.Request {
 	ctx := r.Context()
-	ctx = context.WithValue(ctx, key, val)
+	ctx = context.WithValue(ctx, csrfContext(key), val)
 	return r.WithContext(ctx)
 }
 


### PR DESCRIPTION
…context.

```
The provided key must be comparable and should not be of type string or any other built-in type to avoid collisions between packages using context. Users of WithValue should define their own types for keys. To avoid allocating when assigning to an interface{}, context keys often have concrete type struct{}. Alternatively, exported context key variables' static type should be a pointer or interface.
```
https://golang.org/pkg/context/#WithValue