### PR TITLE
add SameSite support to Cookie options

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	"github.com/gorilla/securecookie"
+	"github.com/pkg/errors"
 )
 
 // CSRF token length in bytes.
@@ -72,6 +71,7 @@ type options struct {
 	FieldName     string
 	ErrorHandler  http.Handler
 	CookieName    string
+	SameSite      http.SameSite
 }
 
 // Protect is HTTP middleware that provides Cross-Site Request Forgery
@@ -167,6 +167,7 @@ func Protect(authKey []byte, opts ...Option) func(http.Handler) http.Handler {
 				httpOnly: cs.opts.HttpOnly,
 				path:     cs.opts.Path,
 				domain:   cs.opts.Domain,
+				samesite: cs.opts.SameSite,
 				sc:       cs.sc,
 			}
 		}

--- a/options.go
+++ b/options.go
@@ -58,6 +58,18 @@ func HttpOnly(h bool) Option {
 	}
 }
 
+// SameSite allows a server define a cookie attribute making it impossible to
+// the browser send this cookie along with cross-site requests. The main goal
+// is mitigate the risk of cross-origin information leakage, and provides some
+// protection against cross-site request forgery attacks.
+//
+// See https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00 for details
+func SameSite(s http.SameSite) Option {
+	return func(cs *csrf) {
+		cs.opts.SameSite = s
+	}
+}
+
 // ErrorHandler allows you to change the handler called when CSRF request
 // processing encounters an invalid token or request. A typical use would be to
 // provide a handler that returns a static HTML file with a HTTP 403 status. By

--- a/store.go
+++ b/store.go
@@ -27,6 +27,7 @@ type cookieStore struct {
 	httpOnly bool
 	path     string
 	domain   string
+	samesite http.SameSite
 	sc       *securecookie.SecureCookie
 }
 
@@ -64,6 +65,7 @@ func (cs *cookieStore) Save(token []byte, w http.ResponseWriter) error {
 		HttpOnly: cs.httpOnly,
 		Secure:   cs.secure,
 		Path:     cs.path,
+		SameSite: cs.samesite,
 		Domain:   cs.domain,
 	}
 

--- a/store_test.go
+++ b/store_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"github.com/gorilla/securecookie"
+	"github.com/pkg/errors"
 )
 
 // Check store implementations
@@ -68,7 +67,7 @@ func TestCookieDecode(t *testing.T) {
 	// Test with a nil hash key
 	sc := securecookie.New(nil, nil)
 	sc.MaxAge(age)
-	st := &cookieStore{cookieName, age, true, true, "", "", sc}
+	st := &cookieStore{cookieName, age, true, true, "", "", http.SameSiteDefaultMode, sc}
 
 	// Set a fake cookie value so r.Cookie passes.
 	r.Header.Set("Cookie", fmt.Sprintf("%s=%s", cookieName, "notacookie"))
@@ -86,7 +85,7 @@ func TestCookieEncode(t *testing.T) {
 	// Test with a nil hash key
 	sc := securecookie.New(nil, nil)
 	sc.MaxAge(age)
-	st := &cookieStore{cookieName, age, true, true, "", "", sc}
+	st := &cookieStore{cookieName, age, true, true, "", "", http.SameSiteDefaultMode, sc}
 
 	rr := httptest.NewRecorder()
 


### PR DESCRIPTION
1.  I've added SameSite as an option to cookieStore and csrf.Option with relevant tests. SameSite was added to the net/http package on in [Go 1.11 release](https://golang.org/doc/go1.11) 
2. Also added relevant tests when SameSite is not set or when set with Lax\Strict mode
