### PR TITLE
Support exclusion of paths from CSRF check

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -61,9 +61,10 @@ type csrf struct {
 
 // options contains the optional settings for the CSRF middleware.
 type options struct {
-	MaxAge int
-	Domain string
-	Path   string
+	MaxAge  int
+	Domain  string
+	Exclude []string
+	Path    string
 	// Note that the function and field names match the case of the associated
 	// http.Cookie field instead of the "correct" HTTPOnly name that golint suggests.
 	HttpOnly      bool
@@ -184,6 +185,13 @@ func (cs *csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				cs.h.ServeHTTP(w, r)
 				return
 			}
+		}
+	}
+
+	for _, path := range cs.opts.Exclude {
+		if r.URL.Path == path {
+			cs.h.ServeHTTP(w, r)
+			return
 		}
 	}
 

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -41,6 +41,27 @@ func TestProtect(t *testing.T) {
 	}
 }
 
+// TestExclude is a test to make sure that certain paths can be excluded from
+// the CSRF check.
+func TestExclude(t *testing.T) {
+	s := http.NewServeMux()
+	s.HandleFunc("/", testHandler)
+
+	p := Protect(testKey, Exclude("/"))(s)
+	rr := httptest.NewRecorder()
+
+	r, err := http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p.ServeHTTP(rr, r)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("middleware failed to pass to the next handler: got %v want %v", rr.Code, http.StatusOK)
+	}
+}
+
 // TestCookieOptions is a test to make sure the middleware correctly sets cookie options
 func TestCookieOptions(t *testing.T) {
 	s := http.NewServeMux()

--- a/options.go
+++ b/options.go
@@ -25,8 +25,8 @@ func Domain(domain string) Option {
 	}
 }
 
-// Paths that you want excluded from the CSRF check, for example endpoints that
-// would receive webhooks.
+// Exclude paths from CSRF checks, for example endpoints that would receive
+// webhooks.
 func Exclude(paths ...string) Option {
 	return func(cs *csrf) {
 		cs.opts.Exclude = paths

--- a/options.go
+++ b/options.go
@@ -25,6 +25,14 @@ func Domain(domain string) Option {
 	}
 }
 
+// Paths that you want excluded from the CSRF check, for example endpoints that
+// would receive webhooks.
+func Exclude(paths ...string) Option {
+	return func(cs *csrf) {
+		cs.opts.Exclude = paths
+	}
+}
+
 // Path sets the cookie path. Defaults to the path the cookie was issued from
 // (recommended).
 //

--- a/options.go
+++ b/options.go
@@ -25,11 +25,12 @@ func Domain(domain string) Option {
 	}
 }
 
-// Exclude paths from CSRF checks, for example endpoints that would receive
-// webhooks.
-func Exclude(paths ...string) Option {
+// Exclude allows for a set of patterns to be excluded from a CSRF check. Each
+// string will be matched against as a regular expression, for example both of
+// the following would be valid: "/example", "^/api/[a-z]+$"
+func Exclude(patterns ...string) Option {
 	return func(cs *csrf) {
-		cs.opts.Exclude = paths
+		cs.opts.Exclude = patterns
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func eqslice(s1 []string, s2 []string) bool {
+func eqslice(s1, s2 []string) bool {
 	if len(s1) != len(s2) {
 		return false
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -6,12 +6,27 @@ import (
 	"testing"
 )
 
+func eqslice(s1 []string, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+
+	for i := range s1 {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Tests that options functions are applied to the middleware.
 func TestOptions(t *testing.T) {
 	var h http.Handler
 
 	age := 86400
 	domain := "gorillatoolkit.org"
+	exclude := []string{"/path1", "/path2", "/path3"}
 	path := "/forms/"
 	header := "X-AUTH-TOKEN"
 	field := "authenticity_token"
@@ -21,6 +36,7 @@ func TestOptions(t *testing.T) {
 	testOpts := []Option{
 		MaxAge(age),
 		Domain(domain),
+		Exclude(exclude...),
 		Path(path),
 		HttpOnly(false),
 		Secure(false),
@@ -39,6 +55,10 @@ func TestOptions(t *testing.T) {
 
 	if cs.opts.Domain != domain {
 		t.Errorf("Domain not set correctly: got %v want %v", cs.opts.Domain, domain)
+	}
+
+	if !eqslice(cs.opts.Exclude, exclude) {
+		t.Errorf("Exclude not set correctly: got %v want %v", cs.opts.Exclude, exclude)
 	}
 
 	if cs.opts.Path != path {


### PR DESCRIPTION
Potential use case would be for excluding endpoints that receive webhooks from third-parties from CSRF checks.