### PR TITLE
Add trusted origins feature

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -72,7 +72,7 @@ type options struct {
 	FieldName      string
 	ErrorHandler   http.Handler
 	CookieName     string
-	TrustedOrigins []*url.URL
+	TrustedOrigins []string
 }
 
 // Protect is HTTP middleware that provides Cross-Site Request Forgery
@@ -238,7 +238,7 @@ func (cs *csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			if !valid {
 				for _, trustedOrigin := range cs.opts.TrustedOrigins {
-					if sameOrigin(trustedOrigin, referer) {
+					if referer.Host == trustedOrigin {
 						valid = true
 						break
 					}

--- a/csrf.go
+++ b/csrf.go
@@ -66,12 +66,13 @@ type options struct {
 	Path   string
 	// Note that the function and field names match the case of the associated
 	// http.Cookie field instead of the "correct" HTTPOnly name that golint suggests.
-	HttpOnly      bool
-	Secure        bool
-	RequestHeader string
-	FieldName     string
-	ErrorHandler  http.Handler
-	CookieName    string
+	HttpOnly       bool
+	Secure         bool
+	RequestHeader  string
+	FieldName      string
+	ErrorHandler   http.Handler
+	CookieName     string
+	TrustedOrigins []*url.URL
 }
 
 // Protect is HTTP middleware that provides Cross-Site Request Forgery
@@ -233,7 +234,18 @@ func (cs *csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			if sameOrigin(r.URL, referer) == false {
+			valid := sameOrigin(r.URL, referer)
+
+			if !valid {
+				for _, trustedOrigin := range cs.opts.TrustedOrigins {
+					if sameOrigin(trustedOrigin, referer) {
+						valid = true
+						break
+					}
+				}
+			}
+
+			if valid == false {
 				r = envError(r, ErrBadReferer)
 				cs.opts.ErrorHandler.ServeHTTP(w, r)
 				return

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -3,7 +3,6 @@ package csrf
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 )
@@ -278,13 +277,7 @@ func TestBadReferer(t *testing.T) {
 func TestTrustedReferer(t *testing.T) {
 	s := http.NewServeMux()
 
-	trustedOrigin, err := url.Parse("http://golang.org/")
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	p := Protect(testKey, TrustedOrigins([]*url.URL{trustedOrigin}))(s)
+	p := Protect(testKey, TrustedOrigins([]string{"golang.org"}))(s)
 
 	var token string
 	s.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -281,9 +281,11 @@ func TestTrustedReferer(t *testing.T) {
 		shouldPass    bool
 	}{
 		{[]string{"golang.org"}, true},
-		{[]string{"golang.org", "api.example.com"}, true},
-		{[]string{"https://example.com/foo"}, false},
-		// etc
+		{[]string{"api.example.com", "golang.org"}, true},
+		{[]string{"http://golang.org"}, false},
+		{[]string{"https://golang.org"}, false},
+		{[]string{"http://example.com"}, false},
+		{[]string{"example.com"}, false},
 	}
 
 	for _, item := range testTable {

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -275,42 +275,62 @@ func TestBadReferer(t *testing.T) {
 // TestTrustedReferer checks that HTTPS requests with a Referer that does not
 // match the request URL correctly but is a trusted origin pass CSRF validation.
 func TestTrustedReferer(t *testing.T) {
-	s := http.NewServeMux()
 
-	p := Protect(testKey, TrustedOrigins([]string{"golang.org"}))(s)
-
-	var token string
-	s.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token = Token(r)
-	}))
-
-	// Obtain a CSRF cookie via a GET request.
-	r, err := http.NewRequest("GET", "https://www.gorillatoolkit.org/", nil)
-	if err != nil {
-		t.Fatal(err)
+	testTable := []struct {
+		trustedOrigin []string
+		shouldPass    bool
+	}{
+		{[]string{"golang.org"}, true},
+		{[]string{"golang.org", "api.example.com"}, true},
+		{[]string{"https://example.com/foo"}, false},
+		// etc
 	}
 
-	rr := httptest.NewRecorder()
-	p.ServeHTTP(rr, r)
+	for _, item := range testTable {
+		s := http.NewServeMux()
 
-	// POST the token back in the header.
-	r, err = http.NewRequest("POST", "https://www.gorillatoolkit.org/", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+		p := Protect(testKey, TrustedOrigins(item.trustedOrigin))(s)
 
-	setCookie(rr, r)
-	r.Header.Set("X-CSRF-Token", token)
+		var token string
+		s.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token = Token(r)
+		}))
 
-	// Set a non-matching Referer header.
-	r.Header.Set("Referer", "http://golang.org/")
+		// Obtain a CSRF cookie via a GET request.
+		r, err := http.NewRequest("GET", "https://www.gorillatoolkit.org/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	rr = httptest.NewRecorder()
-	p.ServeHTTP(rr, r)
+		rr := httptest.NewRecorder()
+		p.ServeHTTP(rr, r)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("middleware failed to pass to the next handler: got %v want %v",
-			rr.Code, http.StatusOK)
+		// POST the token back in the header.
+		r, err = http.NewRequest("POST", "https://www.gorillatoolkit.org/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		setCookie(rr, r)
+		r.Header.Set("X-CSRF-Token", token)
+
+		// Set a non-matching Referer header.
+		r.Header.Set("Referer", "http://golang.org/")
+
+		rr = httptest.NewRecorder()
+		p.ServeHTTP(rr, r)
+
+		if item.shouldPass {
+			if rr.Code != http.StatusOK {
+				t.Fatalf("middleware failed to pass to the next handler: got %v want %v",
+					rr.Code, http.StatusOK)
+			}
+		} else {
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("middleware failed reject a non-matching Referer header: got %v want %v",
+					rr.Code, http.StatusForbidden)
+			}
+		}
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -1,6 +1,9 @@
 package csrf
 
-import "net/http"
+import (
+	"net/http"
+	"net/url"
+)
 
 // Option describes a functional option for configuring the CSRF handler.
 type Option func(*csrf)
@@ -94,6 +97,18 @@ func FieldName(name string) Option {
 func CookieName(name string) Option {
 	return func(cs *csrf) {
 		cs.opts.CookieName = name
+	}
+}
+
+// TrustedOrigins configures a set of origins (referrer) that are trusted for
+// unsafe requests in addition to the origin of the server itself
+//
+// One valid use case for this option is where you have one domain for the backend
+// and one domain for the frontend of your application, so you can send
+// requests directly from the frontend to the backend with valid CSRF requests.
+func TrustedOrigins(origins []*url.URL) Option {
+	return func(cs *csrf) {
+		cs.opts.TrustedOrigins = origins
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -99,12 +99,11 @@ func CookieName(name string) Option {
 	}
 }
 
-// TrustedOrigins configures a set of origins (referrer) that are trusted for
-// unsafe requests in addition to the origin of the server itself
-//
-// One valid use case for this option is where you have one domain for the backend
-// and one domain for the frontend of your application, so you can send
-// requests directly from the frontend to the backend with valid CSRF requests.
+// TrustedOrigins configures a set of origins (Referers) that are considered as trusted.
+// This will allow cross-domain CSRF use-cases - e.g. where the front-end is served
+// from a different domain than the API server - to correctly pass a CSRF check.
+
+// You should only provide origins you own or have full control over.
 func TrustedOrigins(origins []string) Option {
 	return func(cs *csrf) {
 		cs.opts.TrustedOrigins = origins

--- a/options.go
+++ b/options.go
@@ -102,7 +102,7 @@ func CookieName(name string) Option {
 // TrustedOrigins configures a set of origins (Referers) that are considered as trusted.
 // This will allow cross-domain CSRF use-cases - e.g. where the front-end is served
 // from a different domain than the API server - to correctly pass a CSRF check.
-
+//
 // You should only provide origins you own or have full control over.
 func TrustedOrigins(origins []string) Option {
 	return func(cs *csrf) {

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package csrf
 
 import (
 	"net/http"
-	"net/url"
 )
 
 // Option describes a functional option for configuring the CSRF handler.
@@ -106,7 +105,7 @@ func CookieName(name string) Option {
 // One valid use case for this option is where you have one domain for the backend
 // and one domain for the frontend of your application, so you can send
 // requests directly from the frontend to the backend with valid CSRF requests.
-func TrustedOrigins(origins []*url.URL) Option {
+func TrustedOrigins(origins []string) Option {
 	return func(cs *csrf) {
 		cs.opts.TrustedOrigins = origins
 	}


### PR DESCRIPTION
Closes #116 

I added tests and I accept feedbacks on the API. ~I throught about accepting a `[]string` on the added option but we would need to return an error in the case of a URL being invalid, for example~.

**EDIT:** Now the API is more Django-like, accepting `[]string` as a list of trusted hosts to check.