### PR TITLE
bugfix: correctly set a defaultMaxAge when MaxAge isn't called

### DIFF
--- a/options.go
+++ b/options.go
@@ -6,7 +6,8 @@ import "net/http"
 type Option func(*csrf)
 
 // MaxAge sets the maximum age (in seconds) of a CSRF token's underlying cookie.
-// Defaults to 12 hours.
+// Defaults to 12 hours. Call csrf.MaxAge(0) to explicitly set session-only
+// cookies.
 func MaxAge(age int) Option {
 	return func(cs *csrf) {
 		cs.opts.MaxAge = age
@@ -117,6 +118,9 @@ func parseOptions(h http.Handler, opts ...Option) *csrf {
 	// Set here to allow package users to override the default.
 	cs.opts.Secure = true
 	cs.opts.HttpOnly = true
+
+	// Default; only override this if the package user explicitly calls MaxAge(0)
+	cs.opts.MaxAge = defaultAge
 
 	// Range over each options function and apply it
 	// to our csrf type to configure it. Options functions are

--- a/options_test.go
+++ b/options_test.go
@@ -71,3 +71,26 @@ func TestOptions(t *testing.T) {
 			cs.opts.CookieName, name)
 	}
 }
+
+func TestMaxAge(t *testing.T) {
+	t.Run("Ensure the default MaxAge is applied", func(t *testing.T) {
+		handler := Protect(testKey)(nil)
+		csrf := handler.(*csrf)
+		cs := csrf.st.(*cookieStore)
+
+		if cs.maxAge != defaultAge {
+			t.Fatalf("default maxAge not applied: got %d (want %d)", cs.maxAge, defaultAge)
+		}
+	})
+
+	t.Run("Support an explicit MaxAge of 0 (session-only)", func(t *testing.T) {
+		handler := Protect(testKey, MaxAge(0))(nil)
+		csrf := handler.(*csrf)
+		cs := csrf.st.(*cookieStore)
+
+		if cs.maxAge != 0 {
+			t.Fatalf("zero (0) maxAge not applied: got %d (want %d)", cs.maxAge, 0)
+		}
+	})
+
+}


### PR DESCRIPTION
Fixes #119 - a regression introduced in #39 that fails to set the default MaxAge for cookies. 