### PR TITLE
Don't set a default samesite for backwards compatibility

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -62,6 +62,9 @@ type SameSiteMode int
 
 // SameSite options
 const (
+	// SameSiteDefaultMode sets an invalid SameSite header which defaults to
+	// 'Lax' in most browsers, but may cause some browsers to ignore the cookie
+	// entirely.
 	SameSiteDefaultMode SameSiteMode = iota + 1
 	SameSiteLaxMode
 	SameSiteStrictMode

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/pkg/errors v0.8.0
 )
+
+go 1.13

--- a/options.go
+++ b/options.go
@@ -152,9 +152,6 @@ func parseOptions(h http.Handler, opts ...Option) *csrf {
 	cs.opts.Secure = true
 	cs.opts.HttpOnly = true
 
-	// Default to blank to maintain backwards compatibility
-	cs.opts.SameSite = SameSiteDefaultMode
-
 	// Default; only override this if the package user explicitly calls MaxAge(0)
 	cs.opts.MaxAge = defaultAge
 


### PR DESCRIPTION
Also add a comment over SameSiteDefaultMode discouraging its use.

The specific issue I ran into is that the default behaviour of `gorilla/csrf` is to include an invalid `SameSite` attribute on the cookie without doing any `SameSite` configuration.

This broke some users of the site in question because older versions of chrome (apparently the version shipped with android 8) treats an invalid samesite attribute as grounds to drop the cookie entirely rather than just default it to lax.

This updates it to use the zero-value by default for `http.SameSite` rather than `SameSiteDefaultMode`, which has different behaviour from the zero value.

xref https://github.com/golang/go/issues/36990 which, when resolved, may inform this. I do think that no matter how that issue is resolved, the better default for `opts.SameSite` here is `0` though.