### PR TITLE
Not providing any token in requests results in wrong error message

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@
 # Please keep the list sorted.
 
 adiabatic <adiabatic@users.noreply.github.com>
+Florian D. Loch <me@fdlo.ch>
 Google LLC (https://opensource.google.com)
 jamesgroat <james@groat.com>
 Joshua Carp <jm.carp@gmail.com>

--- a/csrf.go
+++ b/csrf.go
@@ -282,8 +282,23 @@ func (cs *csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Retrieve the combined token (pad + masked) token and unmask it.
-		requestToken := unmask(cs.requestToken(r))
+		// Retrieve the combined token (pad + masked) token...
+		maskedToken, err := cs.requestToken(r)
+
+		if err != nil {
+			r = envError(r, ErrBadToken)
+			cs.opts.ErrorHandler.ServeHTTP(w, r)
+			return
+		}
+
+		if maskedToken == nil {
+			r = envError(r, ErrNoToken)
+			cs.opts.ErrorHandler.ServeHTTP(w, r)
+			return
+		}
+
+		// ... and unmask it.
+		requestToken := unmask(maskedToken)
 
 		// Compare the request token against the real token
 		if !compareTokens(requestToken, realToken) {

--- a/csrf.go
+++ b/csrf.go
@@ -274,14 +274,6 @@ func (cs *csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// If the token returned from the session store is nil for non-idempotent
-		// ("unsafe") methods, call the error handler.
-		if realToken == nil {
-			r = envError(r, ErrNoToken)
-			cs.opts.ErrorHandler.ServeHTTP(w, r)
-			return
-		}
-
 		// Retrieve the combined token (pad + masked) token...
 		maskedToken, err := cs.requestToken(r)
 

--- a/csrf.go
+++ b/csrf.go
@@ -276,7 +276,6 @@ func (cs *csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// Retrieve the combined token (pad + masked) token...
 		maskedToken, err := cs.requestToken(r)
-
 		if err != nil {
 			r = envError(r, ErrBadToken)
 			cs.opts.ErrorHandler.ServeHTTP(w, r)

--- a/helpers.go
+++ b/helpers.go
@@ -105,7 +105,7 @@ func unmask(issued []byte) []byte {
 
 // requestToken returns the issued token (pad + masked token) from the HTTP POST
 // body or HTTP header. It will return nil if the token fails to decode.
-func (cs *csrf) requestToken(r *http.Request) []byte {
+func (cs *csrf) requestToken(r *http.Request) ([]byte, error) {
 	// 1. Check the HTTP header first.
 	issued := r.Header.Get(cs.opts.RequestHeader)
 
@@ -123,14 +123,19 @@ func (cs *csrf) requestToken(r *http.Request) []byte {
 		}
 	}
 
+	// Return nil (equivalent to empty byte slice) if no token was found
+	if issued == "" {
+		return nil, nil
+	}
+
 	// Decode the "issued" (pad + masked) token sent in the request. Return a
 	// nil byte slice on a decoding error (this will fail upstream).
 	decoded, err := base64.StdEncoding.DecodeString(issued)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
-	return decoded
+	return decoded, nil
 }
 
 // generateRandomBytes returns securely generated random bytes.


### PR DESCRIPTION
See #150 .

**Summary of Changes**

1. extend tests to verify the problem
2. extend signature of  ```helpers.requestToken()``` to also return ```error``` to differentiate between an empty/non-existing 
token and an actual error
3. check for empty token and raise ```ErrNoToken```
4. remove conditional never becoming true 
5.  added myself to the AUTHORS file. I am not craving for fame and I am not vain either, I just assumed it to be good style with this repo. Please drop this if I am wrong.
