### PR TITLE
Remove pkg/errors dependency

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package csrf

--- a/context.go
+++ b/context.go
@@ -4,17 +4,15 @@ package csrf
 
 import (
 	"context"
+	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 func contextGet(r *http.Request, key string) (interface{}, error) {
 	val := r.Context().Value(key)
 	if val == nil {
-		return nil, errors.Errorf("no value exists in the context for key %q", key)
+		return nil, fmt.Errorf("no value exists in the context for key %q", key)
 	}
-
 	return val, nil
 }
 

--- a/csrf.go
+++ b/csrf.go
@@ -1,11 +1,10 @@
 package csrf
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
-
-	"github.com/pkg/errors"
 
 	"github.com/gorilla/securecookie"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/gorilla/csrf
 
-require (
-	github.com/gorilla/securecookie v1.1.1
-	github.com/pkg/errors v0.9.1
-)
+require github.com/gorilla/securecookie v1.1.1
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/store.go
+++ b/store.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package csrf

--- a/store_legacy.go
+++ b/store_legacy.go
@@ -1,4 +1,6 @@
+//go:build !go1.11
 // +build !go1.11
+
 // file for compatibility with go versions prior to 1.11
 
 package csrf

--- a/store_legacy_test.go
+++ b/store_legacy_test.go
@@ -1,4 +1,6 @@
+//go:build !go1.11
 // +build !go1.11
+
 // file for compatibility with go versions prior to 1.11
 
 package csrf

--- a/store_legacy_test.go
+++ b/store_legacy_test.go
@@ -4,13 +4,12 @@
 package csrf
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	"github.com/gorilla/securecookie"
 )

--- a/store_test.go
+++ b/store_test.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package csrf

--- a/store_test.go
+++ b/store_test.go
@@ -3,13 +3,12 @@
 package csrf
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	"github.com/gorilla/securecookie"
 )


### PR DESCRIPTION
Remove pkg/errors and use error implementation from the standard
library. This change should not introduce any functionality change, as
the error usage is very basic.