### PR TITLE
Token from context

### DIFF
--- a/context.go
+++ b/context.go
@@ -10,7 +10,11 @@ import (
 )
 
 func contextGet(r *http.Request, key string) (interface{}, error) {
-	val := r.Context().Value(key)
+	return valueFromContext(r.Context(), key)
+}
+
+func valueFromContext(ctx context.Context, key string) (interface{}, error) {
+	val := ctx.Value(key)
 	if val == nil {
 		return nil, fmt.Errorf("no value exists in the context for key %q", key)
 	}

--- a/csrf.go
+++ b/csrf.go
@@ -19,7 +19,6 @@ const (
 	errorKey     string = "gorilla.csrf.Error"
 	skipCheckKey string = "gorilla.csrf.Skip"
 	cookieName   string = "_gorilla_csrf"
-	errorPrefix  string = "gorilla/csrf: "
 )
 
 var (

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,7 @@
 package csrf
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
@@ -14,7 +15,14 @@ import (
 // a JSON response body. An empty token will be returned if the middleware
 // has not been applied (which will fail subsequent validation).
 func Token(r *http.Request) string {
-	if val, err := contextGet(r, tokenKey); err == nil {
+	return TokenFromContext(r.Context())
+}
+
+// TokenFromContext returns a masked CSRF token ready for passing into HTML template or
+// a JSON response body. An empty token will be returned if the middleware
+// has not been applied (which will fail subsequent validation).
+func TokenFromContext(ctx context.Context) string {
+	if val, err := valueFromContext(ctx, tokenKey); err == nil {
 		if maskedToken, ok := val.(string); ok {
 			return maskedToken
 		}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

In order for `csrf` to play nicely with libraries like [huma](https://github.com/danielgtaylor/huma) is seems beneficial to be able to retrieve a token not just from a `http.Request` but also straight from the `context.Context`.
This avoids workarounds like creating a dummy request just to pass along the context.
Additionally, it feels more natural to me to pass the actually required value (with is a `context.Context`) instead of the value wrapped with something else that is not really required for retrieving the token.

## Related Tickets & Documents

n. a.

- Related Issue #
- Closes #

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: changes should be covered by existing tests already, adjustment very minor
- [ ] I need help with writing tests

## Run verifications and test

- [X] `make verify` is passing
- [X] `make test` is passing
