### PR TITLE
[REFACTOR] Remove custom contains in favor of std lib impl

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -254,7 +254,7 @@ func (cs *csrf) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// HTTP methods not defined as idempotent ("safe") under RFC7231 require
 	// inspection.
-	if !contains(safeMethods, r.Method) {
+	if !slices.Contains(safeMethods, r.Method) {
 		var isPlaintext bool
 		val := r.Context().Value(PlaintextHTTPContextKey)
 		if val != nil {

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -153,7 +153,7 @@ func TestBadCookie(t *testing.T) {
 	r = createRequest("POST", "/", false)
 
 	// Replace the cookie prefix
-	badHeader := strings.Replace(cookieName+"=", rr.Header().Get("Set-Cookie"), "_badCookie", -1)
+	badHeader := strings.ReplaceAll(cookieName+"=", rr.Header().Get("Set-Cookie"), "_badCookie")
 	r.Header.Set("Cookie", badHeader)
 	r.Header.Set("X-CSRF-Token", token)
 	r.Header.Set("Referer", "http://www.gorillatoolkit.org/")

--- a/helpers.go
+++ b/helpers.go
@@ -189,18 +189,6 @@ func xorToken(a, b []byte) []byte {
 	return res
 }
 
-// contains is a helper function to check if a string exists in a slice - e.g.
-// whether a HTTP method exists in a list of safe methods.
-func contains(vals []string, s string) bool {
-	for _, v := range vals {
-		if v == s {
-			return true
-		}
-	}
-
-	return false
-}
-
 // envError stores a CSRF error in the request context.
 func envError(r *http.Request, err error) *http.Request {
 	return contextSave(r, errorKey, err)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -102,7 +102,10 @@ func TestMultipartFormToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mp.Close()
+	err = mp.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	r = httptest.NewRequest("POST", "/", &b)
 	r.Host = "www.gorillatoolkit.org"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

Replace custom `contains` helper function with standard library's `slices.Contains`

## Changes
  - Removed custom `contains()` function from helpers.go
  - Updated csrf.go to use `slices.Contains()` instead
  - All tests pass successfully

## Rationale
This simplifies the codebase by leveraging Go's standard library instead of maintaining a custom implementation. Both have O(n) complexity, so there's no performance impact.


## Related Tickets & Documents
N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: 
  - Changes made simplify long-term maintenance, without altering core application logic
- [ ] I need help with writing tests

## Run verifications and test

- [X] `make verify` is passing 

⚠️ NOTE: Per contributing guidelines, `make verify` should be run before PR submission, in running this I noticed failures unrelated to my changes - so while I'm here and since I'm dealing with `strings` lib changes, I've gone ahead and addressed - though out of scope from my intended change, I hope you don't mind

- [X] `make test` is passing
